### PR TITLE
Prevent scroll on mouse selection and multiple carets

### DIFF
--- a/src/main/kotlin/com/dobodox/adaptivecaretscroll/logic/EditorScrollManager.kt
+++ b/src/main/kotlin/com/dobodox/adaptivecaretscroll/logic/EditorScrollManager.kt
@@ -23,7 +23,7 @@ class EditorScrollManager(private val scrollListener: ScrollCaretListener) : Edi
     companion object {
         fun attachToEditor( scrollListener: ScrollCaretListener, editor: Editor) {
             editor.caretModel.addCaretListener(scrollListener)
-            editor.contentComponent.addMouseListener(scrollListener)
+            editor.addEditorMouseListener(scrollListener)
         }
     }
 
@@ -47,7 +47,7 @@ class EditorScrollManager(private val scrollListener: ScrollCaretListener) : Edi
         val caretModel = editor.caretModel
         // Remove the scrollListener from the released editor
         caretModel.removeCaretListener(scrollListener)
-        editor.contentComponent.removeMouseListener(scrollListener)
+        editor.removeEditorMouseListener(scrollListener)
     }
 
     /**


### PR DESCRIPTION
Made a change to use the editor mouse listener. This listener has access to the editor that the change was made to. Having this allows us to check if there are selections before forcing a caret position changed event. 